### PR TITLE
Increase base shadekin slots back to 5 from 3

### DIFF
--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -34,8 +34,8 @@
 /datum/job/shadekin
     title = JOB_ANOMALY
     disallow_jobhop = TRUE
-    total_positions = 3
-    spawn_positions = 3
+    total_positions = 5
+    spawn_positions = 5
     supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a> clearly before playing"
 
     flag = NONCREW
@@ -65,7 +65,6 @@
 		return FALSE
 
 /datum/job/shadekin/update_limit(var/comperator)
-	var/current_limit = clamp(comperator / 5, 3, 5) + round(comperator / 50)
 	if(current_limit > total_positions)
 		total_positions = current_limit
 


### PR DESCRIPTION
## About The Pull Request

Previously before the dynamic change was implemented, the maximum amount of shadekins was 5. This was previously reduced to 3 with the inclusion of the dynamic pop code.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
change: Shadekin spawn slots from 3 to 5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
